### PR TITLE
added explicit culture info

### DIFF
--- a/Code/Synnotech.Time.Tests/CalculateIntervalForSameTimeNextDayTests.cs
+++ b/Code/Synnotech.Time.Tests/CalculateIntervalForSameTimeNextDayTests.cs
@@ -1,35 +1,45 @@
 ﻿using System;
-using System.Globalization;
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Synnotech.Xunit;
 using Xunit;
 
 namespace Synnotech.Time.Tests
 {
     public static class CalculateIntervalForSameTimeNextDayTests
     {
-        static CalculateIntervalForSameTimeNextDayTests()
-        {
-            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
-        }
-
         [Theory]
-        [MemberData(nameof(CalculateTimeSpansData))]
-        public static void CalculateTimeSpans(DateTime now, TimeSpan expected)
-        {
-            var startTime = new DateTime(1, 1, 1, 4, 15, 0, DateTimeKind.Local);
+        [MemberData(nameof(NonSpecificData))]
+        public static void CalculateTimeOfNextDayInNonSpecificCultureScenario(DateTime now, TimeSpan expected) =>
+            CheckTimeSpan(now, expected);
 
-            var actualTimeSpan = now.CalculateIntervalForSameTimeNextDay(startTime);
-
-            actualTimeSpan.Should().Be(expected);
-        }
-
-        public static readonly TheoryData<DateTime, TimeSpan> CalculateTimeSpansData =
+        public static readonly TheoryData<DateTime, TimeSpan> NonSpecificData =
             new ()
             {
                 { new DateTime(2017, 10, 4, 12, 0, 0, DateTimeKind.Local), new TimeSpan(16, 15, 0) }, // Simple example
                 { new DateTime(2016, 12, 31, 4, 15, 1, DateTimeKind.Local), new TimeSpan(23, 59, 59) }, // New Year's Eve
+            };
+
+        [SkippableTheory]
+        [MemberData(nameof(GermanSpecificData))]
+        public static void CalculateTimeOfNextDayInGermanScenario(DateTime now, TimeSpan expected)
+        {
+            Skip.IfNot(TestSettings.Configuration.GetValue<bool>("areGermanCultureSpecificTestsEnabled"));
+            CheckTimeSpan(now, expected);
+        }
+
+        public static readonly TheoryData<DateTime, TimeSpan> GermanSpecificData =
+            new ()
+            {
                 { new DateTime(2017, 03, 25, 18, 0, 0, DateTimeKind.Local), new TimeSpan(9, 15, 0) }, // Begin of Daylight Saving Time
                 { new DateTime(2017, 10, 28, 18, 0, 0, DateTimeKind.Local), new TimeSpan(11, 15, 0) } // End of Daylight Saving Time
             };
+
+        private static void CheckTimeSpan(DateTime now, TimeSpan expected)
+        {
+            var startTime = new DateTime(1, 1, 1, 4, 15, 0, DateTimeKind.Local);
+            var actualTimeSpan = now.CalculateIntervalForSameTimeNextDay(startTime);
+            actualTimeSpan.Should().Be(expected);
+        }
     }
 }

--- a/Code/Synnotech.Time.Tests/CalculateIntervalForSameTimeNextDayTests.cs
+++ b/Code/Synnotech.Time.Tests/CalculateIntervalForSameTimeNextDayTests.cs
@@ -1,11 +1,17 @@
 ﻿using System;
+using System.Globalization;
 using FluentAssertions;
 using Xunit;
 
 namespace Synnotech.Time.Tests
 {
-    public static class CalculateIntervalForSameTimeNextDay
+    public static class CalculateIntervalForSameTimeNextDayTests
     {
+        static CalculateIntervalForSameTimeNextDayTests()
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+        }
+
         [Theory]
         [MemberData(nameof(CalculateTimeSpansData))]
         public static void CalculateTimeSpans(DateTime now, TimeSpan expected)

--- a/Code/Synnotech.Time.Tests/Synnotech.Time.Tests.csproj
+++ b/Code/Synnotech.Time.Tests/Synnotech.Time.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net5.0</TargetFramework>
@@ -15,6 +15,18 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="FluentAssertions" Version="5.10.3" />
+		<PackageReference Include="Synnotech.Xunit" Version="1.1.0" />
+		<PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
 	</ItemGroup>
+
+	<ItemGroup>
+        <None Update="testsettings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="testsettings.Development.json" Condition="Exists('testsettings.Development.json')">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
 
 </Project>

--- a/Code/Synnotech.Time.Tests/testsettings.json
+++ b/Code/Synnotech.Time.Tests/testsettings.json
@@ -1,0 +1,3 @@
+{
+    "areGermanCultureSpecificTestsEnabled": false
+}


### PR DESCRIPTION
The `CalculateIntervalForSameTimeNextDayTests` were not running correctly in GitHub actions because the default culture is "en-US" which does not use daylight saving time . I explicitly set the current thread culture to "de-DE" in the static constructor of this class.